### PR TITLE
Allow inventory to be given as full path not just a file

### DIFF
--- a/ansible_deploy/command_line.py
+++ b/ansible_deploy/command_line.py
@@ -230,6 +230,8 @@ def lock_inventory(lockdir: str, lockpath: str):
     """
     logger.debug("Started lock_inventory for lockdir: %s and lockpath %s.", lockdir, lockpath)
     os.makedirs(lockdir, exist_ok=True)
+    #TODO: Is that possible to do that below more general for instance other platforms?
+    lockpath.replace("/", "_")
 
     try:
         with open(lockpath, "x", encoding="utf8") as fh:

--- a/ansible_deploy/command_line.py
+++ b/ansible_deploy/command_line.py
@@ -334,7 +334,7 @@ def run_task(config: dict, options: dict, inventory: str):
         sys.exit(70)
     else:
         for playbook in playbooks:
-            command = ["ansible-playbook", "-l", options["infra"], "-i", inventory, playbook]
+            command = ["ansible-playbook", "-i", inventory, playbook]
             logger.debug("Running '%s'.", command)
             try:
                 with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as \

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ README = read(str(HERE)+"/README.md")
 # This call to setup() does all the work
 setup(
     name="ansible-deploy",
-    version="0.0.4",
+    version="0.0.6",
     description="Wrapper around ansible-playbook allowing configurable tasks and permissions",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
We create a lock file based on that config, so it can contain '/' on
Linux.